### PR TITLE
Clean up and vector support

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,13 +1,41 @@
+#include <algorithm>
 #include <iostream>
+#include <vector>
+#include <string>
 #include "web.hpp"
 
+namespace Web {
+
+	template<typename T> 
+	std::ostream& WriteToStream(std::ostream& stream, const std::vector<T>& data)
+	{
+		for (const auto& d : data)
+		{
+			stream << d;
+		}
+		return stream;
+	}
+}
+
+Web::Div createNameList(const std::vector<std::string>& names)
+{
+	std::vector<Web::P> paragraphs;
+
+	std::transform(names.begin(), names.end(), std::back_inserter(paragraphs),
+		[](const std::string& name)
+	{
+		return Web::P{ name };
+	});
+
+	return Web::Div{ std::move(paragraphs) };
+}
 
 int main()
 {
 	auto para = Web::P{ "hello" };
 	std::cout << para << "\n";
 
-	auto div = Web::Div {
+	auto div = Web::Div{
 		Web::P { "Hello World" }
 	};
 	std::cout << div << "\n";
@@ -16,7 +44,8 @@ int main()
 		Web::Body {
 			Web::H1{ "This is our title" },
 			Web::Br{},
-			Web::P { "Hello World" }
+			Web::P { "Hello World" },
+			createNameList({"John", "Jane", "Eric"})
 		}
 	};
 	std::cout << doc1 << "\n";


### PR DESCRIPTION
Added vector support to printing through use of an overloadable function.
Added a macro to more easily write out simple tags such as P and H1.
Added an example showing adding a vector of paragraphs inside of a div and fixed the stack overflow this caused